### PR TITLE
박희범/week1/boj1541, boj1758, boj1931, boj2217

### DIFF
--- a/src/박희범/week1/boj1541_hb.java
+++ b/src/박희범/week1/boj1541_hb.java
@@ -1,0 +1,36 @@
+package 박희범.week1;
+
+import java.util.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class boj1541_hb {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static void main(String[] args) throws IOException {
+        String input = br.readLine();
+        String[] convert = input.split("\\+");
+        List<Integer> num = new ArrayList<>();
+        for(String s : convert){
+            String[] nums = s.split("-");
+            for (String sNum : nums) {
+                num.add(Integer.parseInt(sNum));
+            }
+        }
+        int delimIdx = 1;
+        for (int i = 0; i < input.length(); i++) {
+            if(input.charAt(i) == '-')
+                break;
+            if(input.charAt(i) == '+')
+                delimIdx++;
+        }
+        int min = 0;
+        for (int i = 0; i < num.size(); i++) {
+            if(i < delimIdx)
+                min += num.get(i);
+            else
+                min -= num.get(i);
+        }
+        System.out.println(min);
+    }
+}

--- a/src/박희범/week1/boj1758_hb.java
+++ b/src/박희범/week1/boj1758_hb.java
@@ -1,0 +1,27 @@
+package 박희범.week1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class boj1758_hb {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+        Integer[] arr = new Integer[N];
+        for(int i = 0; i < N; i++){
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+        Arrays.sort(arr, (o1, o2) -> o2 - o1);
+        long max = 0;
+        for (int i = 0; i < N; i++) {
+            int tip = arr[i] - i;
+            if (tip <= 0) {
+                break;
+            }
+            max += tip;
+        }
+        System.out.println(max);
+    }
+}

--- a/src/박희범/week1/boj1931_hb.java
+++ b/src/박희범/week1/boj1931_hb.java
@@ -1,0 +1,35 @@
+package 박희범.week1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class boj1931_hb {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+        int[][] arr = new int[N][2];
+        StringTokenizer st;
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            arr[i][0] = Integer.parseInt(st.nextToken());
+            arr[i][1] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(arr, (o1, o2) -> {
+            if(o1[1] == o2[1])
+                return o1[0] - o2[0];
+            return o1[1] - o2[1];
+        });
+        int cnt = 0;
+        int end = -1;
+        for(int[] schedule : arr){
+            if(end <= schedule[0]){
+                end = schedule[1];
+                cnt++;
+            }
+        }
+        System.out.println(cnt);
+    }
+}

--- a/src/박희범/week1/boj2217_hb.java
+++ b/src/박희범/week1/boj2217_hb.java
@@ -1,0 +1,28 @@
+package 박희범.week1;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class boj2217_hb {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+        Integer[] rope = new Integer[N];
+        for (int i = 0; i < N; i++) {
+            rope[i] = Integer.parseInt(br.readLine());
+        }
+        Arrays.sort(rope, (o1, o2) -> o2 - o1);
+        int max = 0;
+        int idx = 0;
+        while(idx < N){
+            int w = rope[idx] * (idx + 1);
+            if(max < w)
+                max = w;
+            idx++;
+        }
+        System.out.println(max);
+    }
+}


### PR DESCRIPTION
## boj2217 로프
처음 시도한 방식은 가장 큰 줄부터 들어올리다가 못 드는 줄이 생기면 답을 리턴하는 식이였다. 그러나 max값이 갱신 안되는 것을 확인하고, 모든 줄을 매달아보는 로직으로 고침
<br>
##  boj1758 알바생 강호
값이 50억까지 나올 수 있다. 자나깨나 자료형 조심! 
<br>
## boj1541 잃어버린 괄호
식의 모든 값을 더하다가 - 연산이 나오는 순간 뒤의 값들을 모두 뺀다
<br>
## boj1931 회의실 배정
회의 마치는 시간 기준 가장 빨리 끝나는 다음 회의를 고름 + 시작 시간과 끝나는 시간이 같을 수 있다는 점을 유의 
