### PR TITLE
박희범/week2/boj10986, boj11659, boj11660, pgs42883

### DIFF
--- a/src/박희범/week2/boj10986_hb.java
+++ b/src/박희범/week2/boj10986_hb.java
@@ -1,0 +1,37 @@
+package 박희범.week2;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class boj10986_hb {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int[] arr = new int[N];
+        long[] sum = new long[N];
+        st = new StringTokenizer(br.readLine());
+        for(int i = 0; i < N; i++)
+            arr[i] = Integer.parseInt(st.nextToken());
+
+        sum[0] = arr[0];
+        for (int i = 1; i < N; i++)
+            sum[i] = arr[i] + sum[i - 1];
+
+        Map<Long, Integer> map = new HashMap<>();
+        for (int i = 0; i < N; i++)
+            map.put(sum[i] % M, map.getOrDefault(sum[i] % M, 0) + 1);
+
+        long res = map.getOrDefault(0L, 0);
+        for (Map.Entry<Long, Integer> entry : map.entrySet()) {
+            long n = entry.getValue();
+            if(n > 1)
+                res += n * (n - 1) / 2;
+        }
+        System.out.println(res);
+    }
+}

--- a/src/박희범/week2/boj11659_hb.java
+++ b/src/박희범/week2/boj11659_hb.java
@@ -1,0 +1,30 @@
+package 박희범.week2;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class boj11659_hb {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int[] sumArr = new int[N + 1];
+        st = new StringTokenizer(br.readLine());
+        sumArr[1] = Integer.parseInt(st.nextToken());
+        for (int i = 2; i <= N; i++) {
+            sumArr[i] = Integer.parseInt(st.nextToken());
+            sumArr[i] += sumArr[i - 1];
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int s = Integer.parseInt(st.nextToken());
+            int e = Integer.parseInt(st.nextToken());
+            bw.write(sumArr[e] - sumArr[s - 1]+"\n");
+        }
+        bw.flush();
+        bw.close();
+    }
+}

--- a/src/박희범/week2/boj11660_hb.java
+++ b/src/박희범/week2/boj11660_hb.java
@@ -1,0 +1,36 @@
+package 박희범.week2;
+
+import java.io.*;
+import java.util.StringTokenizer;
+
+public class boj11660_hb {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int[][] arrSum = new int[N + 1][N + 1];
+        for (int i = 1; i < arrSum.length; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j < arrSum.length; j++) {
+                arrSum[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        for (int i = 1; i < arrSum.length; i++) {
+            for (int j = 1; j < arrSum.length; j++) {
+                arrSum[i][j] = arrSum[i][j] + arrSum[i][j -1] + arrSum[i-1][j] - arrSum[i - 1][j - 1];
+            }
+        }
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int r1 = Integer.parseInt(st.nextToken());
+            int c1 = Integer.parseInt(st.nextToken());
+            int r2 = Integer.parseInt(st.nextToken());
+            int c2 = Integer.parseInt(st.nextToken());
+            bw.write(arrSum[r2][c2] - arrSum[r2][c1 - 1] - arrSum[r1 - 1][c2] + arrSum[r1 - 1][c1 - 1] +"\n");
+        }
+        bw.flush();
+        bw.close();
+    }
+}

--- a/src/박희범/week2/pgs42883_hb.java
+++ b/src/박희범/week2/pgs42883_hb.java
@@ -1,0 +1,21 @@
+package 박희범.week2;
+
+public class pgs42883_hb {
+    public String solution(String number, int k) {
+        StringBuilder sb = new StringBuilder();
+        for(int i = 0; i < number.length(); i++){
+            int top = sb.length() - 1;
+
+            while(top >= 0 && k > 0 && sb.charAt(top) < number.charAt(i)){
+                sb.deleteCharAt(top--);
+                k--;
+            }
+            sb.append(number.charAt(i));
+        }
+        while(k > 0){
+            sb.deleteCharAt(sb.length() - 1);
+            k--;
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
### 누적합
쿼리(M)사이즈가 큰 문제는 데이터를 전처리시켜 쿼리들을 O(logN)이나 O(1)로 처리해야 한다라는 방식으로 접근했습니다.(시간초과)

로직을 짜다가 특정 쿼리나 IndexOutOfBoundsException 때문에 따로 처리해야 되는 코드가 생긴다면, 
배열에 padding을 추가하는 것을 고려해보면 좋습니다.

