### PR TITLE
장성훈/week5/boj11724, boj13023, boj2023, pgs42584, pgs43165

### DIFF
--- a/src/장성훈/week5/boj11724_sh.java
+++ b/src/장성훈/week5/boj11724_sh.java
@@ -1,0 +1,48 @@
+package 장성훈.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class boj11724_sh {
+    public static void dfs(int node, List<List<Integer>> adj, boolean[] visited) {
+        visited[node] = true;
+        for (int n : adj.get(node)) {
+            if (!visited[n]) {
+                dfs(n, adj, visited);
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        List<List<Integer>> adj = new ArrayList<>();
+        for (int i = 0; i < n+1; i++) {
+            adj.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            adj.get(a).add(b);
+            adj.get(b).add(a);
+        }
+
+        boolean[] visited = new boolean[n+1];
+        int cnt = 0;
+        for (int i = 1; i <= n; i++) {
+            if (!visited[i]) {
+                dfs(i, adj, visited);
+                cnt++;
+            }
+        }
+        System.out.println(cnt);
+    }
+}

--- a/src/장성훈/week5/boj13023_sh.java
+++ b/src/장성훈/week5/boj13023_sh.java
@@ -1,0 +1,56 @@
+package 장성훈.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class boj13023_sh {
+    public static boolean isFriend = false;
+
+    public static void dfs(int node, List<List<Integer>> adj, boolean[] visited, int cnt) {
+        if (isFriend || cnt == 5) {
+            isFriend = true;
+            return;
+        }
+
+        for (int n : adj.get(node)) {
+            if (!visited[n]) {
+                visited[node] = true;
+                dfs(n, adj, visited, cnt+1);
+                visited[node] = false;
+            }
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        List<List<Integer>> adj = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            adj.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            adj.get(a).add(b);
+            adj.get(b).add(a);
+        }
+
+        boolean[] visited = new boolean[n];
+        for (int i = 0; i < n; i++) {
+            if (!visited[i]) {
+                visited[i] = true;
+                dfs(i, adj, visited, 1);
+                visited[i] = false;
+            }
+        }
+        System.out.println(isFriend ? 1 : 0);
+    }
+}

--- a/src/장성훈/week5/boj2023_sh.java
+++ b/src/장성훈/week5/boj2023_sh.java
@@ -1,0 +1,44 @@
+package 장성훈.week5;
+
+import java.util.Scanner;
+
+public class boj2023_sh {
+    static StringBuilder sb = new StringBuilder();
+
+    public static boolean isPrime(int n) {
+        for (int i = 2; i*i <= n; i++) {
+            if (n % i == 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static void checkSpecialPrime(int num, int digit, int N) {
+        if (digit == N) {
+            if (isPrime(num)) {
+                sb.append(num).append("\n");
+            }
+            return;
+        }
+
+        for (int i = 1; i <= 9; i++) {
+            if (isPrime(num*10 + i)) {
+                checkSpecialPrime(num*10 + i, digit+1, N);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int N = sc.nextInt();
+
+        checkSpecialPrime(2, 1, N);
+        checkSpecialPrime(3, 1, N);
+        checkSpecialPrime(5, 1, N);
+        checkSpecialPrime(7, 1, N);
+
+        System.out.println(sb.toString());
+        sc.close();
+    }
+}

--- a/src/장성훈/week5/pgs42584_sh.java
+++ b/src/장성훈/week5/pgs42584_sh.java
@@ -1,0 +1,31 @@
+package 장성훈.week5;
+
+import java.util.Stack;
+
+public class pgs42584_sh {
+    public int[] solution(int[] prices) {
+        Stack<Integer> stack = new Stack<>();
+
+        int[] answer = new int[prices.length];
+
+        for (int i = 0; i < prices.length; i++) {
+            while (!stack.isEmpty()) {
+                int prev = stack.peek();
+                if (prices[i] >= prices[prev]) {
+                    break;
+                }
+                answer[prev] = i - prev;
+                stack.pop();
+            }
+            stack.push(i);
+        }
+
+        while (!stack.isEmpty()) {
+            int last = stack.peek();
+            answer[last] = prices.length - last - 1;
+            stack.pop();
+        }
+
+        return answer;
+    }
+}

--- a/src/장성훈/week5/pgs43165_sh.java
+++ b/src/장성훈/week5/pgs43165_sh.java
@@ -1,0 +1,27 @@
+package 장성훈.week5;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class pgs43165_sh {
+    public static void main(String[] args) {
+        int[] nums = {1, 1, 1, 1, 1};
+        int target = 3;
+        System.out.println(solution(nums, target));
+    }
+
+    public static int solution(int[] numbers, int target) {
+        Map<Integer, Integer> map = new HashMap<>();
+        map.put(0, 1);  // key를 만들 수 있는 경우의 수
+
+        for (int num : numbers) {
+            Map<Integer, Integer> temp = new HashMap<>();
+            for (Integer key : map.keySet()) {
+                temp.put(key+num, temp.getOrDefault(key+num, 0) + map.get(key));
+                temp.put(key-num, temp.getOrDefault(key-num, 0) + map.get(key));
+            }
+            map = temp; // 경우의 수 목록을 갱신
+        }
+        return map.get(target);
+    }
+}


### PR DESCRIPTION
### [연결 요소의 개수](https://www.acmicpc.net/problem/11724)
 - af225fb85984b1339d67f32f0b6edd2c09df1f49
 - 전형적인 그래프 탐색 문제로, DFS로 풀었습니다.
 - 이 문제는 재귀의 깊이가 깊지않아 DFS로 충분히 풀릴 수 있지만 스택 오버플로우의 우려가 있을 수 있습니다.
 - BFS나 유니온 파인트 기법을 활용해서 풀 수 있을 것 같습니다. 

### [ABCDE](https://www.acmicpc.net/problem/13023)
 - 7b667b3ae1f1c305c7dc7aaa0766a9b6d063023f
 - 문제 번역이 애매해 조건을 이해하는게 힘들었습니다. (사람 5명이 연결된 경우가 존재한다면 성공)
 - 전형적인 그래프 탐색 문제로, DFS와 방문처리 배열을 사용해 방문 가능한 노드를 탐색했습니다. (백트래킹)
 - 만약 재귀의 깊이가 5가 될 경우 성공이라 판단해 모두 종료시키고 1을 출력하도록 했습니다.

### [신기한 소수](https://www.acmicpc.net/problem/2023)
 - c9064cb6be6b88a154be1308a32fcfb3b6e80d79
 - 백트래킹으로 해결했습니다.
 - 모든 숫자를 비교해보면서 소수를 만들 수 있는 경우에 대해서만 다음 자릿수에 대해 소수 체크를 해서 정답을 구했습니다.

### [주식 가격](https://school.programmers.co.kr/learn/courses/30/lessons/42584)
 - a08c3f008b5d48cae53c4930ce5d9e9c5b120f93
 - 처음에는 n^2 로 접근해서 풀었으며, 문제 조건상 시간 초과가 발생할 수 밖에 없었습니다.
 - 이후에는 스택을 활용한 방법을 시도했습니다.
   각 가격이 가격이 안떨어진 경우에는 스택에 들어가고, 떨어진 경우에는 나오도록 했으며, 
   스택(가격이 안떨어진 경우)를 전부 스택에서 꺼내면서 시간을 구했습니다.
 - 최대 O(3n)으로 시간 복잡도 O(n)으로 풀 수 있었습니다.

### [타겟 넘버](https://school.programmers.co.kr/learn/courses/30/lessons/43165)
 - 2b34612e73da8a26ccb8446fa11c955ae52a9591
 - HashMap을 활용한 DP 방식으로 문제를 해결했습니다.
 - 회차별로 만들 수 있는 경우의 수를 HashMap으로 구했으며, 현재 위치의 숫자로 만들 수 있는 key값의 숫자를 계속해서 더해나갔습니다.
 - 예를 들어 숫자가 [1,1,1,1,1] 이렇게 존재한다면 다음과 같이 딕셔너리가 생성됩니다.
   1. {-1=1, 1=1}
   2. {0=2, -2=1, 2=1}
   3. {-1=3, 1=3, -3=1, 3=1}
   4. {0=6, -2=4, 2=4, -4=1, 4=1}
   5. {-1=10, 1=10, -3=5, 3=5, -5=1, 5=1}  // map.get(target=3) : 5
