### PR TITLE
조우형/week5/boj11724,boj2023,boj13023,pgs43165,pgs42584

### DIFF
--- a/src/조우형/week5/boj11724_wh.java
+++ b/src/조우형/week5/boj11724_wh.java
@@ -1,0 +1,62 @@
+package 조우형.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class boj11724_wh {
+
+    static boolean visited[];
+    static ArrayList<Integer>[] graph;
+    static int n, m;
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer stk = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(stk.nextToken());
+        m = Integer.parseInt(stk.nextToken());
+
+        int result = 0;
+
+        graph = new ArrayList[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < m; i++) {
+            stk = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(stk.nextToken());
+            int v = Integer.parseInt(stk.nextToken());
+
+            graph[u].add(v);
+            graph[v].add(u);
+        }
+
+        visited = new boolean[n + 1];
+
+        for (int i = 1; i <= n; i++) {
+            if (!visited[i]){
+                dfs(i);
+                result++;
+            }
+        }
+
+        System.out.println(result);
+    }
+
+    public static void dfs(int n) {
+
+        if (visited[n]){
+            return;
+        }
+
+        visited[n] = true;
+
+        for (int i = 0; i < graph[n].size(); i++) {
+            dfs(graph[n].get(i));
+        }
+    }
+}

--- a/src/조우형/week5/boj13023_wh.java
+++ b/src/조우형/week5/boj13023_wh.java
@@ -1,0 +1,69 @@
+package 조우형.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+public class boj13023_wh {
+
+    static ArrayList<Integer>[] graph;
+    final static int LOOP = 5;
+    static int n,m;
+    static boolean[] visited;
+    static boolean state;
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer stk = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(stk.nextToken());
+        m = Integer.parseInt(stk.nextToken());
+        visited = new boolean[n];
+
+        graph = new ArrayList[n];
+        for (int i = 0; i < n; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < m; i++) {
+            stk = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(stk.nextToken());
+            int v = Integer.parseInt(stk.nextToken());
+
+            graph[u].add(v);
+            graph[v].add(u);
+        }
+
+        state = false;
+
+        for (int i = 0; i < n; i++) {
+            dfs(i, 1);
+            if (state) {
+                break;
+            }
+        }
+
+        System.out.println(state ? 1 : 0);
+    }
+
+    static public void dfs(int start, int cnt) {
+        //System.out.print(start+"\t");
+        //System.out.println("count = " + count);
+        if (cnt == LOOP) {
+            state = true;
+            return;
+        }
+
+        visited[start] = true;
+
+        for (Integer i : graph[start]) {
+
+            if (!visited[i]) {
+                dfs(i, cnt+1);
+            }
+        }
+
+        visited[start] = false;
+
+    }
+}

--- a/src/조우형/week5/boj2023_2_wh.java
+++ b/src/조우형/week5/boj2023_2_wh.java
@@ -1,0 +1,52 @@
+package 조우형.week5;
+
+import java.io.*;
+
+public class boj2023_2_wh {
+    static int n;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        n = Integer.parseInt(br.readLine());
+
+        int[] primeOne = new int[]{2, 3, 5, 7}; //소수인 첫번째 자리수
+
+        if (n == 1) {
+            for (int i : primeOne) {
+                System.out.println(i);
+            }
+        }
+        else
+            for (int i : primeOne) {
+                dfs(i, 0);
+            }
+    }
+
+    static void dfs(int num, int k) {
+        //System.out.println("dfs");
+        if (isPrime(num)) {
+            if (k == n-1) {
+                //System.out.println("k = " + k);
+                System.out.println(num);
+            }
+            else
+                for (int i = 1; i < 10; i = i + 2) {
+                    //System.out.println(num);
+                    //System.out.println("k = " + k);
+                    dfs(num * 10 + i, k + 1);
+
+                }
+        }
+    }
+
+    static boolean isPrime(int num) {
+        //System.out.println("isPrime");
+        for (int i = 2; i <= Math.sqrt(num); i++) {
+            if (num % i == 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/조우형/week5/boj2023_wh.java
+++ b/src/조우형/week5/boj2023_wh.java
@@ -1,0 +1,64 @@
+package 조우형.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+
+public class boj2023_wh {
+
+    static boolean[] isPrime;
+    public static void main(String[] args) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+
+        int size = 100000000;
+        isPrime = new boolean[size];
+        isPrime[0] = true;
+        isPrime[1] = true;
+
+        for (int i = 2; i < size; i++) {
+
+            if (!isPrime[i]){
+                for (int j = i + i; j < size; j += i) {
+                    isPrime[j] = true;
+                }
+            }
+        }
+
+        for (double i = Math.pow(10, n - 1); i < Math.pow(10, n); i++) {
+            int t = (int) i;
+            char[] arr = String.valueOf(t).toCharArray();
+
+            boolean state = dfs(1, arr);
+            if (state) {
+                sb.append(t+ "\n");
+            }
+        }
+
+        System.out.println(sb.toString());
+    }
+
+    static public boolean dfs(int idx, char[] arr) {
+
+        if (idx > arr.length) {
+            //System.out.println("Arrays.toString(arr) = " + Arrays.toString(arr));
+           // System.out.println("arr.length = " + arr.length);
+            //System.out.println("idx = " + idx);
+            return true;
+        }
+
+        StringBuilder temp = new StringBuilder();
+        for (int i = 0; i < idx; i++) {
+            temp.append(arr[i]);
+        }
+
+        if (!isPrime[Integer.parseInt(temp.toString())]) {
+            return dfs(idx + 1, arr);
+        }
+        else {
+            return false;
+        }
+    }
+}

--- a/src/조우형/week5/pgs42584_wh.java
+++ b/src/조우형/week5/pgs42584_wh.java
@@ -1,0 +1,25 @@
+package 조우형.week5;
+
+import java.util.*;
+public class pgs42584_wh {
+    public int[] solution(int[] prices) {
+        int[] ans = new int[prices.length];
+        Stack<Integer> stack = new Stack();
+
+        for (int i = 0; i < prices.length; i++) {
+            while (!stack.isEmpty() && prices[i] < prices[stack.peek()]) {
+                ans[stack.peek()] = i - stack.peek();
+                stack.pop(); // 답을 구했기 때문에 stack에서 제거한다
+            }
+            stack.push(i);
+        }
+
+        while (!stack.isEmpty()) { // 값을 구하지 못한 index == 끝까지 가격이 떨어지지 않은 주식
+            ans[stack.peek()] = prices.length - stack.peek() - 1;
+            stack.pop();
+        }
+
+        return ans;
+    }
+
+}

--- a/src/조우형/week5/pgs43165_wh.java
+++ b/src/조우형/week5/pgs43165_wh.java
@@ -1,0 +1,42 @@
+package 조우형.week5;
+
+public class pgs43165_wh {
+
+    static String[] plusMinus = {"+","-"};
+    boolean[] visited;
+    static int[] numbers;
+    static int target;
+    static int answer;
+
+    public int solution(int[] numbers, int target) {
+        this.numbers = numbers;
+        this.target = target;
+
+        answer = 0;
+
+        visited = new boolean[numbers.length];
+
+        for(int i = 0; i < 2; i++) {
+            dfs(i, 0, 0);
+        }
+
+        return answer;
+    }
+
+    static void dfs(int sym, int idx, int sum) {
+
+        if (idx == numbers.length) {
+            return;
+        }
+
+        sum += Integer.parseInt(plusMinus[sym] + numbers[idx]);
+
+        if (sum == target && idx == numbers.length-1) {
+            answer++;
+        }
+
+        for (int i = 0; i < plusMinus.length; i++) {
+            dfs(i, idx+1, sum);
+        }
+    }
+}


### PR DESCRIPTION
**백준 11724. 연결 요소의 개수**
- dfs로 풀이
- 방향성이 없기 때문에 양쪽 노드에 서로 연결되어 있는 것을 표시해줘야 합니다.
- ArrayList로 입력 받으면서 서로 연결되어 있는 것을 확인할 수 있도록 처리해줬습니다.

**신기한 소수**
- 접근 방법 : 소수를 처리하기 위해 소수 리스트를 만들 생각을 했다. 하지만 8자리의 수까지 소수를 구해야 했어서 메모리 초과가 발생했다.
- 자릿수가 한 개인 소수는 2,3,5,7이므로 이 수부터 탐색한다.
- 다음 자리수를 추가할 때 짝수가 아닌 홀수를 추가하고 소수인지 판별을 한다.
- 소수라면 재귀함수로 자릿수를 하나 늘린다.

**친구 관계 파악하기**
- 친구 관계는 무방향이기 때문에 "연결 요소의 개수" 문제와 마찬가지로 양방향 처리를 해준다.
- 친구 관계의 연속된 길이가 5임을 찾는 문제이다. 그래서 첫번째 친구부터 시작하므로 count를 1로 두고 탐색을 시작한다.
- 방문하지 않은 친구들을 찾아가면서 길이가 5가 되면 state를 true로 저장하고, 탐색을 종료한다.
- 그리고 방문처리를 하고서 연결된 친구들을 탐색한 이후에는 방문처리를 해제해준다.
- 그렇지 않으면 다른 탐색에서 방문처리가 되어있어 제대로 탐색을 할 수 없는 경우가 발생한다.

**타켓 넘버**
- 이 문제에서 dfs 재귀로 탐색할 부분은 +와 -이다. 수는 순차적으로 다 더해줘야하기 때문에
- numbers의 첫번째 값에 부호를 추가하여 sum에 더하고, 다음 두번째 값에도 두 가지 부호를 부여하여 합을 구한다.
- numbers의 index가 최대가 되었을 때 sum이 되었을 때 경우의 수를 추가해줘서 결과를 구한다.