### PR TITLE
김민지/week5/boj11724, boj2023, boj13023, pgs43165

### DIFF
--- a/src/김민지/week5/boj11724.java
+++ b/src/김민지/week5/boj11724.java
@@ -1,0 +1,58 @@
+package 김민지.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class boj11724 {
+    static ArrayList<Integer>[] graph;
+    static boolean[] visited;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        graph = new ArrayList[N + 1];
+        visited = new boolean[N + 1];
+        int cnt = 0;
+
+        // 초기화
+        for (int i = 1; i <= N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        // 그래프 채우기
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+
+            // 방향이 없으므로 모두에게 채워주기
+            graph[u].add(v);
+            graph[v].add(u);
+        }
+
+        for (int i = 1; i <= N; i++) {
+            if (!visited[i]) {
+                cnt++;
+                dfs(i);
+            }
+        }
+        System.out.println(cnt);
+    }
+
+    public static void dfs(int v) {
+        if (visited[v]) {
+            return;
+        }
+        visited[v] = true;
+        for (int e : graph[v]) {
+            if (!visited[e]) {
+                dfs(e);
+            }
+        }
+    }
+}

--- a/src/김민지/week5/boj13023.java
+++ b/src/김민지/week5/boj13023.java
@@ -1,0 +1,61 @@
+package 김민지.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+public class boj13023 {
+    // ABCDE
+    static ArrayList<Integer>[] graph;
+    static boolean[] visited;
+    static boolean foundABCDE;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int cnt = 0;
+
+        graph = new ArrayList[N];
+        visited = new boolean[N];
+        foundABCDE = false;
+
+        for (int i = 0; i < N; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            // 방향이 없으므로 모두에게 채워주기
+            graph[a].add(b);
+            graph[b].add(a);
+        }
+
+        for (int i = 1; i < N; i++) {
+            if (!foundABCDE) {
+                dfs(i, 0);
+            }
+        }
+        System.out.println(0);
+    }
+
+    public static void dfs(int v, int depth) {
+        if (depth == 4 && !foundABCDE) {
+            System.out.println(1);
+            System.exit(0);
+        }
+        visited[v] = true;
+        for (int a : graph[v]) {
+            if (!visited[a]) {
+                dfs(a, depth + 1);
+            }
+        }
+        visited[v] = false; // 백트레킹
+    }
+}

--- a/src/김민지/week5/boj2023.java
+++ b/src/김민지/week5/boj2023.java
@@ -1,0 +1,44 @@
+package 김민지.week5;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class boj2023 {
+    static int N;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        N = Integer.parseInt(br.readLine());
+
+        dfs(2, 1);
+        dfs(3, 1);
+        dfs(5, 1);
+        dfs(7, 1);
+    }
+
+    public static void dfs(int num, int len) {
+        if (len == N) {
+            if (isPrime(num))
+                System.out.println(num);
+            return;
+        }
+        for (int i = 1; i < 10; i++) {
+            if (i % 2 == 0) {
+                continue;
+            }
+            if (isPrime(num*10 + i)) {
+                dfs(num*10 + i, len + 1);
+            }
+        }
+    }
+
+     public static boolean isPrime(int n) {
+        for (int i=2; i <= n/2; i++) {
+            if (n % i == 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/src/김민지/week5/prg43165.java
+++ b/src/김민지/week5/prg43165.java
@@ -1,0 +1,27 @@
+package 김민지.week5;
+
+public class prg43165 {
+    int cnt = 0;
+    int target;
+
+    public int solution(int[] numbers, int t) {
+        target = t;
+        dfs(numbers, 0, 0);
+        return cnt;
+    }
+
+    public void dfs(int[] numbers, int depth, int result) {
+        if (depth == numbers.length) {
+            if (result == target) {
+                cnt++;
+            }
+            return;
+        }
+
+        int tmp1 = result - numbers[depth];
+        int tmp2 = result + numbers[depth];
+
+        dfs(numbers, depth+1, tmp1);
+        dfs(numbers, depth+1, tmp2);
+    }
+}


### PR DESCRIPTION
### 연결 요소의 개수 - 10fcd62b2479473f4277f6e4beb67f90f7ba3758
  - 방향이 없기 때문에, 간선들을 그래프의 각 노드에 넣어준다. 방문한 노드를 체크해주는 로직을 사용하여 연결된 요소들을 확인한다.

### 신기한 소수 - 1278a924c56fc9a75ac43fa71c08f284cb87ac7f
  - 왼쪽을 기준으로 1,2,3,4 자리들이 모두 소수여야 하기 때문에 소수인지 판별하며 숫자를 선별한다.
  - 짝수를 제외한 숫자로 자릿수를 늘려가며 num이 소수인지 확인한다.

### ABCDE - 2e4db7d6b1524e52c56941a253ceb93a49c5de04
  - 문제의 조건을 이해하는데 어려움을 겪었다. 처음에는 모든 그래프가 연결되어 있으면 즉, 11724문제 처럼 cnt가 1이면 조건이 충족되는 것이 아닐까? 라고 생각해서 문제를 풀었으나 테스트 케이스는 통과했으나 최종적으로는 해결되지 않았다.
  - 문제 자체가 하나의 노드로 전체를 방문할 수 있는 연결성을 가졌는지를 파악하는게 중요한 것 같다고 이해를 해서, 기존의 방식으로는 그래프의 연결성을 파악하지 못한다는 점을 이해 했다. 
  - 그래서 depth 값이 꼭 필요했고, 조회할때 이 depth를 0으로 방문했던 노드도 초기화하면서 새롭게 탐색해야 하는 방식으로 바꿔서 접근했다.

### 타겟 넘버 - 90043e8dd30e8814e99384b2a1c81e322b543270
  - 리스트의 순서를 유지한채로 target을 맞춰야 하는 문제이다. 
  - 각 index를 돌면서 +, -를 해준 결과값과 depth 를 넘겨주며 전체 리스트를 순회하며 조건에 맞는 케이스가 왔을 때, cnt를 늘려준다.
