### PR TITLE
박희범/week6/boj1167, boj1260, boj2178, pgs43164

### DIFF
--- a/src/박희범/week6/boj1167_hb.java
+++ b/src/박희범/week6/boj1167_hb.java
@@ -1,0 +1,55 @@
+package 박희범.week6;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class boj1167_hb {
+    static int max;
+    static int maxNode;
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    public static void main(String[] args) throws IOException {
+        int N = Integer.parseInt(br.readLine());
+        List<List<int[]>> graph = new ArrayList<>();
+        for (int i = 0; i <= N; i++) {
+            graph.add(new ArrayList<>());
+        }
+        StringTokenizer st;
+        for (int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            List<int[]> list = graph.get(start);
+            while (st.hasMoreTokens()) {
+                int node = Integer.parseInt(st.nextToken());
+                if (node == -1) {
+                    break;
+                }
+                int weight = Integer.parseInt(st.nextToken());
+                list.add(new int[]{node, weight});
+                list.add(new int[]{start, weight});
+            }
+        }
+
+        dfs(1, graph, 0, new boolean[N + 1]);
+        dfs(maxNode, graph, 0, new boolean[N + 1]);
+
+        System.out.println(max);
+    }
+
+    static void dfs(int cur, List<List<int[]>> graph, int length, boolean[] visited) {
+        if (length > max) {
+            max = length;
+            maxNode = cur;
+        }
+        visited[cur] = true;
+        for (int[] edge : graph.get(cur)) {
+            if (visited[edge[0]])
+                continue;
+            dfs(edge[0], graph, length + edge[1], visited);
+        }
+    }
+}

--- a/src/박희범/week6/boj1260_hb.java
+++ b/src/박희범/week6/boj1260_hb.java
@@ -1,0 +1,62 @@
+package 박희범.week6;
+
+import java.io.*;
+import java.util.*;
+
+public class boj1260_hb {
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+        int V = Integer.parseInt(st.nextToken());
+        List<List<Integer>> graph = new ArrayList<>();
+        for (int i = 0; i <= N; i++) {
+            graph.add(new ArrayList<>());
+        }
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            graph.get(a).add(b);
+            graph.get(b).add(a);
+        }
+        for (int i = 1; i <= N; i++) {
+            Collections.sort(graph.get(i));
+        }
+        dfs(V, graph, new boolean[graph.size()]);
+        bw.write("\n");
+        bfs(V, graph);
+        bw.flush();
+        bw.close();
+    }
+
+    static void dfs(int cur, List<List<Integer>> graph, boolean[] visited) throws IOException {
+        bw.write(cur + " ");
+        visited[cur] = true;
+        for (int next : graph.get(cur)) {
+            if (visited[next])
+                continue;
+            dfs(next, graph, visited);
+        }
+    }
+
+    static void bfs(int V, List<List<Integer>> graph) throws IOException {
+        boolean[] visited = new boolean[graph.size()];
+        Queue<Integer> q = new LinkedList<>();
+        q.add(V);
+        visited[V] = true;
+        bw.write(V+" ");
+        while (!q.isEmpty()){
+            int cur = q.poll();
+            for (int next : graph.get(cur)) {
+                if(visited[next])
+                    continue;
+                visited[next] = true;
+                bw.write(next+" ");
+                q.add(next);
+            }
+        }
+    }
+}

--- a/src/박희범/week6/boj2178_hb.java
+++ b/src/박희범/week6/boj2178_hb.java
@@ -1,0 +1,55 @@
+package 박희범.week6;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class boj2178_hb {
+    static int[] dr = {-1, 0, 0, 1};
+    static int[] dc = {0, -1, 1, 0};
+    static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st;
+        st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        char[][] maze = new char[n][m];
+        for (int i = 0; i < n; i++) {
+            String s = br.readLine();
+            for (int j = 0; j < m; j++) {
+                maze[i][j] = s.charAt(j);
+            }
+        }
+        System.out.println(bfs(n, m, maze));
+    }
+    static int bfs(int n , int m, char[][] maze){
+        Queue<int[]> q = new LinkedList<>();
+        boolean[][] visited = new boolean[n][m];
+        visited[0][0] = true;
+        q.add(new int[]{0, 0, 1});
+        while(!q.isEmpty()){
+            int[] cur = q.poll();
+            if(cur[0] == n - 1 && cur[1]  == m - 1){
+                return cur[2];
+            }
+            for (int i = 0; i < 4; i++) {
+                int nr = cur[0] + dr[i];
+                int nc = cur[1] + dc[i];
+                if(OOD(nr, nc, n, m) || maze[nr][nc] == '0' || visited[nr][nc])
+                    continue;
+                visited[nr][nc] = true;
+                q.add(new int[]{nr, nc, cur[2] + 1});
+            }
+        }
+        return -1;
+    }
+
+    static boolean OOD(int nr, int nc, int n, int m){
+        if(nr < 0 || nc < 0 || nr >= n || nc >= m)
+            return true;
+        return false;
+    }
+}

--- a/src/박희범/week6/pgs43164_hb.java
+++ b/src/박희범/week6/pgs43164_hb.java
@@ -1,0 +1,58 @@
+package 박희범.week6;
+
+import java.util.*;
+
+class pgs43164_hb {
+    class Node {
+        String to;
+        boolean visited;
+        Node(String t, boolean v){
+            to = t;
+            visited = v;
+        }
+    }
+    public String[] solution(String[][] tickets) {
+        String[] answer = {};
+        Map<String, List<Node>> graph = new HashMap<>();
+        int idx = 0;
+        for(String[] ticket : tickets){
+            List<Node> list = graph.getOrDefault(ticket[0], new ArrayList<>());
+            list.add(new Node(ticket[1], false));
+            graph.put(ticket[0], list);
+        }
+        Set<String> set = new HashSet<>();
+        for(String[] ticket : tickets){
+            set.add(ticket[0]);
+            set.add(ticket[1]);
+        }
+        for(List<Node> list : graph.values()){
+            list.sort((o1, o2) -> o1.to.compareTo(o2.to));
+        }
+        List<String> visited = dfs("ICN", graph, new ArrayList<>(){{add("ICN");}}, tickets.length + 1);
+        answer = new String[visited.size()];
+        for(int i = 0; i < visited.size(); i++){
+            answer[i] = visited.get(i);
+        }
+        return answer;
+    }
+
+    List<String> dfs(String cur, Map<String, List<Node>> graph, List<String> visited, int size){
+        if(visited.size() == size)
+            return visited;
+        List<String> result = null;
+        if(graph.get(cur) == null)
+            return new ArrayList<>();
+        for(Node node : graph.get(cur)){
+            if(node.visited)
+                continue;
+            visited.add(node.to);
+            node.visited = true;
+            result = dfs(node.to, graph, visited, size);
+            if(result.size() == size)
+                break;
+            node.visited = false;
+            visited.remove(visited.size() - 1);
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
### 트리의 지름 - 25face71f1fcef400225c51d38073e82c23b57d4
- 트리의 지름을 완전 탐색으로 구하면 트리 노드의 갯수는 최대 10만개로 O(n^2)을 사용하여 시간초과가 날 것이라 생각했습니다.

사용한 로직은,
1. 어떤 노드에서 가장 먼 노드를 찾습니다.
2. 찾은 노드에서 가장 먼 노드를 찾고 그 거리를 구합니다.
트리의 지름을 찾아서 쭉 늘렸다고 생각해봅시다. 나머지 노드들도 직선처럼 만들면 아래 그림과 같이 생겼을 겁니다.
![image](https://github.com/wxxhyeong/kb-study/assets/91429968/a3a3ac01-7268-45cf-8f54-a925fcfae179)
어떤 점을 찍어서 가장 먼 노드를 찾았을 때, 찾은 노드는 항상 지름의 한 끝 점일 수 밖에 없습니다. 지름보다 긴 노드는 존재하지 않습니다.
그리고 지름의 한 끝 부분에서 가장 거리가 먼 노드는 지름의 나머지 한 점일 수 밖에 없고, 이 길이를 구해 트리의 지름을 얻습니다.

### DFS와 BFS - 42dc5467f862623d55e9892a379538d35f4b1057
- 인접리스트를 오름차순으로 정렬 후 dfs, bfs를 수행했습니다. dfs, bfs에선 방문할때마다 각 원소를 출력해주었습니다.

### 미로탐색 - 95235326a0011064b723d570137f7e3e67142506
- 맵 상에서 상하좌우 움직임을 구현하기 위해 int[] dr, int[] dc를 둬서 방향벡터를 구현했습니다.
- BFS를 수행하면, 시작 노드에서 가까운 노드부터 차례대로 탐색하기 때문에, 끝점에 도달하였을 때 최소 거리인 것이 보장됩니다.

### 여행경로 - eb0d68790a9a47a50fb45ab6c37316508b2bf1b8
- 공항명은 String 타입입니다. 또한 모든 공항을 순회할 때 가능한 경로가 2개 이상일 경우 알파벳 순서가 앞서는 경로를 return 하라는 조건이 있습니다. 우선 이 조건을 만족하기 위해 Map<String, List<Node>> 타입으로 인접리스트?를 구현하였습니다
- 이후 각 List의 Node들을 이름명으로 오름차순 정렬하였고 dfs를 수행했습니다. 오름차순으로 정렬하면 dfs를 수행할 때 가능한 경로 중 알파벳 순서가 가장 빠르다고 보장해줍니다. 때문에 depth만큼 내려갔을 때  early return이 가능합니다. 
- ** 21번째 줄 사용하지 않는 코드 삭제**  
```java
        Set<String> set = new HashSet<>();
        for(String[] ticket : tickets){
            set.add(ticket[0]);
            set.add(ticket[1]);
        }
```