### PR TITLE
장성훈/week6/boj1167, boj1260, boj2178, pgs43164

### DIFF
--- a/src/장성훈/week6/boj1167_sh.java
+++ b/src/장성훈/week6/boj1167_sh.java
@@ -1,0 +1,103 @@
+package 장성훈.week6;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+class Tree {
+    private int V;
+    LinkedList<Edge>[] adjList;
+
+    class Edge {
+        int node, weight;
+
+        public Edge(int node, int weight) {
+            this.node = node;
+            this.weight = weight;
+        }
+    }
+
+    public Tree(int v) {
+        this.V = v;
+        adjList = new LinkedList[v + 1];
+        for (int i = 0; i <= v; i++) {
+            adjList[i] = new LinkedList<>();
+        }
+    }
+
+    public void addEdge(int src, int dest, int w) {
+        adjList[src].add(new Edge(dest, w));
+        adjList[dest].add(new Edge(src, w));
+    }
+
+    public int[] bfs(int start) {
+        boolean[] visited = new boolean[V + 1];
+        int[] res = new int[V + 1];
+        Queue<Integer> queue = new LinkedList<>();
+        queue.add(start);
+        visited[start] = true;
+
+        while (!queue.isEmpty()) {
+            int cur = queue.poll();
+            for (Edge edge : adjList[cur]) {
+                if (!visited[edge.node]) {
+                    visited[edge.node] = true;
+                    res[edge.node] = res[cur] + edge.weight;
+                    queue.add(edge.node);
+                }
+            }
+        }
+
+        return res;
+    }
+
+    public int findLongestPath() {
+        // 가장 먼 노드를 찾기
+        int[] distances = bfs(1);
+        int maxDist = 0, maxNode = 0;
+
+        for (int i = 1; i <= V; i++) {
+            if (distances[i] > maxDist) {
+                maxDist = distances[i];
+                maxNode = i;
+            }
+        }
+
+        // 노드간 최장 거리를 찾기
+        distances = bfs(maxNode);
+        maxDist = 0;
+
+        for (int i = 1; i <= V; i++) {
+            if (distances[i] > maxDist) {
+                maxDist = distances[i];
+            }
+        }
+        return maxDist;
+    }
+}
+
+public class boj1167_sh {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+        Tree tree = new Tree(n);
+
+        StringTokenizer st;
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            int src = Integer.parseInt(st.nextToken());
+            while (true) {
+                int dest = Integer.parseInt(st.nextToken());
+                if (dest == -1) {
+                    break;
+                }
+                int w = Integer.parseInt(st.nextToken());
+                tree.addEdge(src, dest, w);
+            }
+        }
+        System.out.println(tree.findLongestPath());
+    }
+}

--- a/src/장성훈/week6/boj1260_sh.java
+++ b/src/장성훈/week6/boj1260_sh.java
@@ -1,0 +1,58 @@
+package 장성훈.week6;
+
+import java.util.*;
+
+public class boj1260_sh {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int n = sc.nextInt(), m = sc.nextInt(), v = sc.nextInt();
+        boolean[] visited;
+        int[][] graph = new int[n+1][n+1];
+        for (int i = 1; i <= m; i++) {
+            int a = sc.nextInt(), b = sc.nextInt();
+            graph[a][b] = 1;
+            graph[b][a] = 1;
+        }
+
+        visited = new boolean[n+1];
+        dfs(graph,visited,v);
+
+        System.out.println();
+
+        visited = new boolean[n+1];
+        bfs(graph,visited,v);
+    }
+
+    public static void dfs(int[][] graph, boolean[] visited, int v) {
+        visited[v] = true;
+        System.out.print(v+" ");
+        for (int i = 1; i < graph.length; i++) {
+            if (graph[v][i] == 1 && !visited[i]) {
+                dfs(graph,visited,i);
+            }
+        }
+    }
+
+    public static void bfs(int[][] graph, boolean[] visited, int v) {
+        Queue<Integer> queue = new LinkedList<>();
+        queue.add(v);
+        visited[v] = true;
+        while (!queue.isEmpty()) {
+            int cur = queue.poll();
+            System.out.print(cur+" ");
+            for (int i = 0; i < graph[cur].length; i++) {
+                if (graph[cur][i] == 1 && !visited[i]) {
+                    visited[i] = true;
+                    queue.add(i);
+                }
+            }
+        }
+    }
+}
+
+
+//Scanner S = new Scanner(System.in);
+//        int N = S.nextInt(), M = S.nextInt(), V = S.nextInt();
+//int A[][] = new int[N+1][N+1];
+//int C[] = new int[N+1];
+//int i = 0;

--- a/src/장성훈/week6/boj2178_sh.java
+++ b/src/장성훈/week6/boj2178_sh.java
@@ -1,0 +1,64 @@
+package 장성훈.week6;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+// 미로 탐색
+public class boj2178_sh {
+    private static final int[] dx = {0, -1, 0, 1};
+    private static final int[] dy = {1, 0, -1, 0};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[][] maze = new int[n][m];
+
+        for (int i = 0; i < n; i++) {
+//            st = new StringTokenizer(br.readLine());    // 101111
+            String line = br.readLine();
+            for (int j = 0; j < m; j++) {
+                maze[i][j] = line.charAt(j) - '0';
+            }
+        }
+
+        int answer = bfs(maze, n, m);
+        System.out.println(answer);
+    }
+
+    private static int bfs(int[][] maze, int n, int m) {
+        Queue<int[]> queue = new LinkedList<>();
+        queue.add(new int[]{0, 0});
+        maze[0][0] = 1;
+
+        while (!queue.isEmpty()) {
+            int size = queue.size();
+            for (int i = 0; i < size; i++) {
+                int[] cur = queue.poll();
+                int x = cur[0];
+                int y = cur[1];
+
+                if (x == n - 1 && y == m - 1) {
+                    return maze[x][y];
+                }
+
+                for (int k = 0; k < 4; k++) {
+                    int nx = x + dx[k];
+                    int ny = y + dy[k];
+
+                    if (nx >= 0 && ny >= 0 && nx < n && ny < m && maze[nx][ny] == 1){
+                        maze[nx][ny] = maze[x][y] + 1;
+                        queue.add(new int[]{nx, ny});
+                    }
+                }
+            }
+        }
+        return -1;
+    }
+}

--- a/src/장성훈/week6/pgs43164_sh.java
+++ b/src/장성훈/week6/pgs43164_sh.java
@@ -1,73 +1,35 @@
 package 장성훈.week6;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
+import java.util.*;
 
-public class pgs43164_sh {
-    public static void main(String[] args) {
-        String[][] tickets = {{"ICN", "SFO"}, {"ICN", "ATL"}, {"SFO", "ATL"}, {"ATL", "ICN"}, {"ATL", "SFO"}};
-        String[][] tickets2 = {{"ICN", "AAA"}, {"AAA", "ICN"}, {"ICN", "CCC"}, {"CCC", "ICN"}, {"ICN", "DDD"}, {"DDD", "AAA"}};
-        String[][] tickets3 = {{"ICN", "D"}, {"D", "ICN"}, {"ICN", "B"}};
-        solution(tickets3);
+class pgs43164_sh {
+    static boolean[] visited;
+    static ArrayList<String> route;
+
+    public String[] solution(String[][] tickets) {
+        String[] answer = {};
+        visited = new boolean[tickets.length];
+        route = new ArrayList<>();
+
+        DFS("ICN", "ICN", tickets, 0);
+
+        Collections.sort(route);
+        answer = route.get(0).split(" ");
+        return answer;
     }
 
-    public static String[] solution(String[][] tickets) {
-        Arrays.sort(tickets, (o1, o2) -> o1[1].compareTo(o2[1]));
-        HashMap<String, HashMap<String, Integer>> routes = new HashMap<>();
-
-        for (String[] ticket : tickets) {
-            routes.putIfAbsent(ticket[0], new HashMap<>());
-            HashMap<String, Integer> prevRoutes = routes.get(ticket[0]);
-
-            prevRoutes.put(ticket[1], prevRoutes.getOrDefault(ticket[1], 0) + 1);
+    public void DFS(String departure, String arrival, String[][] tickets, int cnt) {
+        if (cnt == tickets.length) {
+            route.add(arrival);
+            return;
         }
 
-        // 출력하기
-        for (HashMap.Entry<String, HashMap<String, Integer>> entry : routes.entrySet()) {
-            String route = entry.getKey();
-            HashMap<String, Integer> prevRoutes = entry.getValue();
-            System.out.println(route);
-            for (String ticket : prevRoutes.keySet()) {
-                System.out.println(ticket + ":" + prevRoutes.get(ticket));
-            }
-            System.out.println();
-        }
-
-        String start = "ICN";
-        ArrayList<String> list = new ArrayList<>();
-        list.add(start);
-        System.out.println();
-
-         System.out.println(dfs("ICN", routes, list, tickets.length + 1));
-//        String[] answer = dfs("ICN", routes, list, tickets.length + 1).toArray(new String[0]);
-
-        return null;//dfs(start, routes, list, tickets.length + 1).toArray(new String[0]);
-    }
-
-    public static ArrayList<String> dfs(String start, HashMap<String, HashMap<String, Integer>> routes, ArrayList<String> path, int target) {
-        if (path.size() == target) {
-            return path;
-        }
-
-        if (routes.containsKey(start)) {
-            HashMap<String, Integer> route = routes.get(start);
-            for (String end : route.keySet()) {
-                if (route.get(end) == 0) {
-                    continue;
-                }
-
-                route.put(end, route.get(end) - 1);
-                ArrayList<String> newPath = new ArrayList<>(path);
-                newPath.add(end);
-                ArrayList<String> temp = dfs(end, routes, newPath, target);
-                if (temp == null || temp.isEmpty()) {
-                    route.put(end, route.get(end) + 1);
-                } else {
-                    return temp;
-                }
+        for (int i = 0; i < tickets.length; i++) {
+            if (departure.equals(tickets[i][0]) && !visited[i]) {
+                visited[i] = true;
+                DFS(tickets[i][1], arrival + " " + tickets[i][1], tickets, cnt + 1);
+                visited[i] = false;
             }
         }
-        return null;
     }
 }

--- a/src/장성훈/week6/pgs43164_sh.java
+++ b/src/장성훈/week6/pgs43164_sh.java
@@ -1,0 +1,73 @@
+package 장성훈.week6;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+
+public class pgs43164_sh {
+    public static void main(String[] args) {
+        String[][] tickets = {{"ICN", "SFO"}, {"ICN", "ATL"}, {"SFO", "ATL"}, {"ATL", "ICN"}, {"ATL", "SFO"}};
+        String[][] tickets2 = {{"ICN", "AAA"}, {"AAA", "ICN"}, {"ICN", "CCC"}, {"CCC", "ICN"}, {"ICN", "DDD"}, {"DDD", "AAA"}};
+        String[][] tickets3 = {{"ICN", "D"}, {"D", "ICN"}, {"ICN", "B"}};
+        solution(tickets3);
+    }
+
+    public static String[] solution(String[][] tickets) {
+        Arrays.sort(tickets, (o1, o2) -> o1[1].compareTo(o2[1]));
+        HashMap<String, HashMap<String, Integer>> routes = new HashMap<>();
+
+        for (String[] ticket : tickets) {
+            routes.putIfAbsent(ticket[0], new HashMap<>());
+            HashMap<String, Integer> prevRoutes = routes.get(ticket[0]);
+
+            prevRoutes.put(ticket[1], prevRoutes.getOrDefault(ticket[1], 0) + 1);
+        }
+
+        // 출력하기
+        for (HashMap.Entry<String, HashMap<String, Integer>> entry : routes.entrySet()) {
+            String route = entry.getKey();
+            HashMap<String, Integer> prevRoutes = entry.getValue();
+            System.out.println(route);
+            for (String ticket : prevRoutes.keySet()) {
+                System.out.println(ticket + ":" + prevRoutes.get(ticket));
+            }
+            System.out.println();
+        }
+
+        String start = "ICN";
+        ArrayList<String> list = new ArrayList<>();
+        list.add(start);
+        System.out.println();
+
+         System.out.println(dfs("ICN", routes, list, tickets.length + 1));
+//        String[] answer = dfs("ICN", routes, list, tickets.length + 1).toArray(new String[0]);
+
+        return null;//dfs(start, routes, list, tickets.length + 1).toArray(new String[0]);
+    }
+
+    public static ArrayList<String> dfs(String start, HashMap<String, HashMap<String, Integer>> routes, ArrayList<String> path, int target) {
+        if (path.size() == target) {
+            return path;
+        }
+
+        if (routes.containsKey(start)) {
+            HashMap<String, Integer> route = routes.get(start);
+            for (String end : route.keySet()) {
+                if (route.get(end) == 0) {
+                    continue;
+                }
+
+                route.put(end, route.get(end) - 1);
+                ArrayList<String> newPath = new ArrayList<>(path);
+                newPath.add(end);
+                ArrayList<String> temp = dfs(end, routes, newPath, target);
+                if (temp == null || temp.isEmpty()) {
+                    route.put(end, route.get(end) + 1);
+                } else {
+                    return temp;
+                }
+            }
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
### 트리의 지름 - 59576e6a6f21fea7e75bcf4fb231eeb7d629839d
- 모든 그래프를 순회하며 노드들 사이의 거리를 구하는 것은 너무 비효율적입니다.
  따라서 가장 멀리 위치한 두개의 노드를 찾는 것이 문제 풀이의 핵심입니다.
- 우선 가장 멀리 위치한 노드를 찾기 위해 탐색을 해주고,
  그 노드에서 가장 멀리 위치한 노드를 찾아 거리를 구해주면 됩니다.
- 아래 그림처럼 생각하면 쉽습니다.
  모든 정점을 실로 연결했다고 생각하고 축 늘어뜨린다 생각하면 됩니다.
  1. 우선 아무 점을 잡아줍니다.
    (c) 로 기준을 잡았다고 했을 때 가장 멀리 위치한 정점은 (e) 가 됩니다.
    (c)를 잡고 축 늘어뜨리면 가장 아래에 오게 되는 정점은 (e)가 됩니다.
    <img width="591" alt="image" src="https://github.com/user-attachments/assets/38eb7d7f-03e0-4453-acf8-45d6050acaf0">

  2. 이번엔 가장 멀리 온 (e)를 잡고 축 늘어뜨립니다.
    (e) 로 기준을 잡았다고 했을 때 가장 멀리 위치한 정점은 (d) 가 됩니다.
    <img width="675" alt="image" src="https://github.com/user-attachments/assets/76262b31-8af2-40d2-a974-13bf59f54826">
- 저는 두 정점을 찾기 위해 BFS를 사용해서 탐색했습니다.

### DFS와 BFS - 89d1d393773fd9841b86b197a9a0e1261cf04ea7
- DFS와 BFS를 구현해서 문제를 해결했습니다.

### 미로탐색 - e925e814d7e6339e93d92a2ed9715b11a12dbc15
- 방문처리를 위해 BFS를 활용했으며, 방향 전환을 위해 dx,dy를 활용했습니다.
- 방문 여부를 확인하기 위한 visited 를 사용하지 않고 방문 거리를 더해나가면서 방문하지 않은 경우(1)을 체크하면서 탐색을 진행했습니다.
 
### 여행경로 - c1875bc
- dfs 로 탐색을 진행했습니다. 
- 메소드의 파라미터로 방문 처리를 위한 테이블을 넘기는 방식으로 문제를 풀었는데 런타임 에러가 발생했습니다.
- static을 활용해 route와 visited가 전역적으로 동작하도록 했습니다.
